### PR TITLE
chore: add GitHub Sponsors to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: jeffersongoncalves
 custom: ["https://buymeacoffee.com/jeffersongoncalves"]


### PR DESCRIPTION
## Summary
- Adds `github: jeffersongoncalves` to `.github/FUNDING.yml` alongside the existing Buy Me a Coffee link, so the native GitHub Sponsors button shows too
